### PR TITLE
Explosion reactions tweak, fix for reactions logging

### DIFF
--- a/code/modules/reagents/Chemistry-Logging.dm
+++ b/code/modules/reagents/Chemistry-Logging.dm
@@ -1,18 +1,12 @@
 
 /var/list/chemical_reaction_logs = list()
 
-/proc/log_chemical_reaction(atom/A, datum/chemical_reaction/R, multiplier)
-	if(!A || !R)
-		return
-
-	var/turf/T = get_turf(A)
-	var/logstr = "[usr ? key_name(usr) : "EVENT"] mixed [R.name] ([R.result]) (x[multiplier]) in \the [A] at [T ? "[T.x],[T.y],[T.z]" : "*null*"]"
+/datum/chemical_reaction/proc/log_it(atom/A)
+	var/logstr = "[usr ? key_name(usr) : "EVENT"] mixed [name] ([result]) in \the [A ? A : "ERROR"]"
 
 	chemical_reaction_logs += "\[[time_stamp()]\] [logstr]"
 
-	if(R.log_is_important)
-		message_admins(logstr)
-	log_admin(logstr)
+	log_admin(logstr, A, log_is_important)
 
 /client/proc/view_chemical_reaction_logs()
 	set name = "Show Chemical Reactions"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -67,6 +67,7 @@
 	if(result)
 		holder.add_reagent(result, amt_produced, data, safety = 1)
 
+	log_it(holder.my_atom)
 	on_reaction(holder, amt_produced)
 
 //called when a reaction processes
@@ -462,25 +463,30 @@
 /datum/chemical_reaction/plastication/on_reaction(var/datum/reagents/holder, var/created_volume)
 	new /obj/item/stack/material/plastic(get_turf(holder.my_atom), created_volume)
 
-/* Grenade reactions */
+/* Explosion reactions */
 
-/datum/chemical_reaction/explosion_potassium
+/datum/chemical_reaction/explosion
 	name = "Explosion"
-	result = null
-	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
-	result_amount = 2
 	mix_message = null
+	result_amount = 2
+	log_is_important = 1
 
-/datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
+/datum/chemical_reaction/explosion/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
-	if(isliving(holder.my_atom))
-		e.amount *= 0.5
-		var/mob/living/L = holder.my_atom
-		if(L.stat != DEAD)
-			e.amount *= 0.5
+	e.set_up(created_volume, holder.my_atom, 0, 0)
 	e.start()
 	holder.clear_reagents()
+
+/datum/chemical_reaction/explosion/potassium
+	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
+
+/datum/chemical_reaction/explosion/nitroglycerin
+	name = "Nitroglycerin"
+	// will be deleted in on_reaction, anyways
+	// result = /datum/reagent/Nitroglycerin
+	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/acid/polyacid = 1, /datum/reagent/acid = 1)
+
+/* Non-explosion reactions for grenades */
 
 /datum/chemical_reaction/flash_powder
 	name = "Flash powder"
@@ -522,25 +528,6 @@
 	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
 	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
 	empulse(location, round(created_volume / 24), round(created_volume / 14), 1)
-	holder.clear_reagents()
-
-/datum/chemical_reaction/nitroglycerin
-	name = "Nitroglycerin"
-	result = /datum/reagent/nitroglycerin
-	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/acid/polyacid = 1, /datum/reagent/acid = 1)
-	result_amount = 2
-	log_is_important = 1
-
-/datum/chemical_reaction/nitroglycerin/on_reaction(var/datum/reagents/holder, var/created_volume)
-	var/datum/effect/effect/system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/2, 1), holder.my_atom, 0, 0)
-	if(isliving(holder.my_atom))
-		e.amount *= 0.5
-		var/mob/living/L = holder.my_atom
-		if(L.stat!=DEAD)
-			e.amount *= 0.5
-	e.start()
-
 	holder.clear_reagents()
 
 /datum/chemical_reaction/napalm


### PR DESCRIPTION
Переписал логику взрывных реакций, починил логирование для реакций.

* Теперь реакции вызывают реальные взрывы и могут гибнуть человека, если реакция будет внутри него. Никаких искр и странных вспышек. Также избавился от копипасты в коде взрыва: теперь потассиумный и нитроглицериновые взрывы имеют общего наследника.

* Все реакции логируются в текстовые логи и логи в отдельной менюшке в педальном интерфейсе. Важные реакции дублируются педалям прямо в чат.

Из проблем:
1. Самый маленький взрыв не вызывает никакого урона, зато слышен на всю станцию - это странно. Но раньше были искры - тоже такое себе решение.
2. Забыл починить аналогичные вызовы химического взрыва в сигаретах и еще там где-то, там надо поменять.

Починю проблемы - залью в билд отдельно. Этот ПР чисто для желающих посмотреть и обсудить.
